### PR TITLE
plist -o and -i can be either a file or a directory

### DIFF
--- a/lib/flip_the_switch/cli.rb
+++ b/lib/flip_the_switch/cli.rb
@@ -9,11 +9,11 @@ module FlipTheSwitch
     end
 
     public
-    class_option :input, type: :string, aliases: '-i', default: defaults[:input], desc: 'Location of the directory containing features.yml file to read'
+    class_option :input, type: :string, aliases: '-i', default: defaults[:input], desc: 'Filename or directory containing features.yml file to read'
     class_option :environment, type: :string, aliases: '-n', default: defaults[:environment], desc: 'Name of environment to read from in features.yml file'
 
     desc 'plist', 'Auto-generates a Features.plist file for enabled/disabled features'
-    method_option :output, type: :string, aliases: '-o', default: defaults[:plist_output], desc: 'Location of the directory in which Features.plist file will be created'
+    method_option :output, type: :string, aliases: '-o', default: defaults[:plist_output], desc: 'Filename or directory in which Features.plist file will be created'
 
     def plist
       plist_generator.generate

--- a/lib/flip_the_switch/generator/plist.rb
+++ b/lib/flip_the_switch/generator/plist.rb
@@ -25,7 +25,11 @@ module FlipTheSwitch
       end
 
       def output_file
-        File.join(output, 'Features.plist')
+        if File.directory?(output)
+          File.join(output, 'Features.plist')
+        else
+          output
+        end
       end
     end
   end

--- a/lib/flip_the_switch/reader/features.rb
+++ b/lib/flip_the_switch/reader/features.rb
@@ -41,7 +41,11 @@ module FlipTheSwitch
       end
 
       def input_file
-        File.join(input, 'features.yml')
+        if File.directory?(input)
+          File.join(input, 'features.yml')
+        else
+          input
+        end
       end
     end
   end

--- a/spec/flip_the_switch/generator/plist_spec.rb
+++ b/spec/flip_the_switch/generator/plist_spec.rb
@@ -14,25 +14,22 @@ describe FlipTheSwitch::Generator::Plist do
     File.delete(output_file) if File.exists?(output_file)
   end
 
-  context 'When the output is a directory' do
-    let(:output) { 'spec/resources' }
-    let(:output_file) { 'spec/resources/Features.plist' }
+  shared_examples "a plist writer" do |output, output_file|
+    let(:output) { output }
+    let(:output_file) { output_file }
 
-    it 'writes a Features.plist file with the enabled features set' do
+    it "writes a #{File.basename(output_file)} file with the features set" do
       subject.generate
 
       expect(File.read(output_file)).to eql(expected_plist_file)
     end
   end
 
+  context 'When the output is a directory' do
+    it_behaves_like "a plist writer", 'spec/resources', 'spec/resources/Features.plist'
+  end
+
   context 'when the output is a file' do
-    let(:output) { 'spec/resources/DasPlist.plist' }
-    let(:output_file) { 'spec/resources/DasPlist.plist' }
-
-    it 'writes a DasPlist.plist file with the enabled features set' do
-      subject.generate
-
-      expect(File.read(output_file)).to eql(expected_plist_file)
-    end
+    it_behaves_like "a plist writer", 'spec/resources/DasPlist.plist', 'spec/resources/DasPlist.plist'
   end
 end

--- a/spec/flip_the_switch/generator/plist_spec.rb
+++ b/spec/flip_the_switch/generator/plist_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe FlipTheSwitch::Generator::Plist do
   subject(:plist) { described_class.new(output, features) }
-  let(:output) { 'tmp' }
   let(:features) { [
     FlipTheSwitch::Feature.new('enabled_feature', true, nil),
     FlipTheSwitch::Feature.new('disabled_feature', false, 'is disabled description')
@@ -15,9 +14,25 @@ describe FlipTheSwitch::Generator::Plist do
     File.delete(output_file) if File.exists?(output_file)
   end
 
-  it 'writes a Features.plist file with the enabled features set' do
-    subject.generate
+  context 'When the output is a directory' do
+    let(:output) { 'spec/resources' }
+    let(:output_file) { 'spec/resources/Features.plist' }
 
-    expect(actual_output_file).to eql(expected_plist_file)
+    it 'writes a Features.plist file with the enabled features set' do
+      subject.generate
+
+      expect(File.read(output_file)).to eql(expected_plist_file)
+    end
+  end
+
+  context 'when the output is a file' do
+    let(:output) { 'spec/resources/DasPlist.plist' }
+    let(:output_file) { 'spec/resources/DasPlist.plist' }
+
+    it 'writes a DasPlist.plist file with the enabled features set' do
+      subject.generate
+
+      expect(File.read(output_file)).to eql(expected_plist_file)
+    end
   end
 end

--- a/spec/flip_the_switch/reader/features_spec.rb
+++ b/spec/flip_the_switch/reader/features_spec.rb
@@ -4,10 +4,10 @@ describe FlipTheSwitch::Reader::Features do
   subject(:reader) { described_class.new(input, environment) }
   let(:environment) { 'beta' }
 
-  context 'when given a real file' do
+  context 'when input is a directory containing a valid features.yml file' do
     let(:input) { 'spec/resources/real' }
 
-    context 'when given an valid environment' do
+    context 'when given adirectory containing features.yml as input' do
       it 'reads the enabled/disabled states of the features for the environment' do
         expect(subject.features).to eql([
             FlipTheSwitch::Feature.new('enabled_feature', true, 'This feature is enabled', [
@@ -26,6 +26,41 @@ describe FlipTheSwitch::Reader::Features do
           subject.features
         }.to raise_error(FlipTheSwitch::Error::InvalidEnvironment)
       end
+    end
+  end
+
+  context 'when input is a valid file' do
+    let(:input) { 'spec/resources/real/features.yml' }
+
+    context 'when given adirectory containing features.yml as input' do
+      it 'reads the enabled/disabled states of the features for the environment' do
+        expect(subject.features).to eql([
+            FlipTheSwitch::Feature.new('enabled_feature', true, 'This feature is enabled', [
+                FlipTheSwitch::Feature.new('sub_feature', false)
+              ]),
+            FlipTheSwitch::Feature.new('disabled_feature', false)
+          ])
+      end
+    end
+
+    context 'when given an invalid environment' do
+      let(:environment) { 'invalid' }
+
+      specify do
+        expect {
+          subject.features
+        }.to raise_error(FlipTheSwitch::Error::InvalidEnvironment)
+      end
+    end
+  end
+
+  context 'when input is an invalid file' do
+    let(:input) { 'spec/resources/invalid_type/features.yml' }
+
+    specify do
+      expect {
+        subject.features
+      }.to raise_error(FlipTheSwitch::Error::InvalidFile)
     end
   end
 


### PR DESCRIPTION
Allows specifying the name of the outputted plist