### PR TITLE
Be more permissive about activesupport dependency

### DIFF
--- a/flip_the_switch.gemspec
+++ b/flip_the_switch.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version = '1.0.0'
   s.license = 'MIT'
 
-  s.add_dependency 'activesupport', '~> 3.2'
+  s.add_dependency 'activesupport', '>= 3.2', '< 5.0'
   s.add_dependency 'thor', '~> 0.19'
   s.add_dependency 'plist', '~> 3.1'
   s.add_dependency 'json-schema', '~> 2.5'


### PR DESCRIPTION
Otherwise the gem can't be used alongside the new version of cocoapods:

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    cocoapods (~> 0.39.0) ruby depends on
      activesupport (>= 4.0.2) ruby

    cocoapods (~> 0.39.0) ruby depends on
      activesupport (>= 4.0.2) ruby

    activesupport (>= 3) ruby

    flip_the_switch (>= 0) ruby depends on
      activesupport (~> 3.2) ruby
```

`< 5.0` is quite optimistic but only a few methods are used anyway. Even better would be to get rid of the dependency altogether  :recycle:  :)

thanks for your work on this, hope all is well!