### PR TITLE
Add bundle specific dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ Guardfile
 .coveralls.yml
 
 #####
+# Bundle
+.bundle
+vendor/
+
+#####
 # Cocoapods
 Pods/
 


### PR DESCRIPTION
Just so that we can install the gems locally using:

    $ bundle install --path=vendor/bundle