### PR TITLE
Subfeature should be added to the generated plist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ Guardfile
 .coveralls.yml
 
 #####
+# Bundle
+.bundle
+vendor/
+
+#####
 # Cocoapods
 Pods/
 

--- a/lib/flip_the_switch/generator/base.rb
+++ b/lib/flip_the_switch/generator/base.rb
@@ -8,6 +8,19 @@ module FlipTheSwitch
 
       protected
       attr_reader :output, :features
+
+      def all_features
+        features.flat_map { |feature|
+          feature_and_sub_features(feature)
+        }
+      end
+
+      private
+      def feature_and_sub_features(feature)
+        [feature] + feature.sub_features.flat_map { |sub_feature|
+          feature_and_sub_features(sub_feature)
+        }
+      end
     end
   end
 end

--- a/lib/flip_the_switch/generator/category.rb
+++ b/lib/flip_the_switch/generator/category.rb
@@ -65,18 +65,6 @@ module FlipTheSwitch
         File.read(File.expand_path("../#{name}.erb", __FILE__))
       end
 
-      def all_features
-        features.flat_map { |feature|
-          feature_and_sub_features(feature)
-        }
-      end
-
-      def feature_and_sub_features(feature)
-        [feature] + feature.sub_features.flat_map { |sub_feature|
-          feature_and_sub_features(sub_feature)
-        }
-      end
-
       def lower_camelize(string)
         str = camelize(string)
         if str.empty?

--- a/lib/flip_the_switch/generator/plist.rb
+++ b/lib/flip_the_switch/generator/plist.rb
@@ -11,7 +11,7 @@ module FlipTheSwitch
       private
 
       def feature_states
-        features.inject({}) do |states, feature|
+        all_features.inject({}) do |states, feature|
           states.merge(feature.name => feature_hash(feature))
         end
       end

--- a/spec/flip_the_switch/generator/plist_spec.rb
+++ b/spec/flip_the_switch/generator/plist_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe FlipTheSwitch::Generator::Plist do
   subject(:plist) { described_class.new(output, features) }
   let(:features) { [
-    FlipTheSwitch::Feature.new('enabled_feature', true, nil),
+    FlipTheSwitch::Feature.new('enabled_feature', true, nil, [ FlipTheSwitch::Feature.new('disabled_subfeature', false, 'subfeature') ]),
     FlipTheSwitch::Feature.new('disabled_feature', false, 'is disabled description')
   ] }
   let(:output_file) { 'tmp/Features.plist' }

--- a/spec/resources/ExpectedFeatures.plist
+++ b/spec/resources/ExpectedFeatures.plist
@@ -9,11 +9,6 @@
 		<key>enabled</key>
 		<false/>
 	</dict>
-	<key>enabled_feature</key>
-	<dict>
-		<key>enabled</key>
-		<true/>
-	</dict>
 	<key>disabled_subfeature</key>
 	<dict>
 		<key>description</key>
@@ -21,6 +16,10 @@
 		<key>enabled</key>
 		<false/>
 	</dict>
-
+	<key>enabled_feature</key>
+	<dict>
+		<key>enabled</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/spec/resources/ExpectedFeatures.plist
+++ b/spec/resources/ExpectedFeatures.plist
@@ -14,5 +14,13 @@
 		<key>enabled</key>
 		<true/>
 	</dict>
+	<key>disabled_subfeature</key>
+	<dict>
+		<key>description</key>
+		<string>subfeature</string>
+		<key>enabled</key>
+		<false/>
+	</dict>
+
 </dict>
 </plist>


### PR DESCRIPTION
Will fix https://github.com/michaelengland/FlipTheSwitch/issues/44

Currently, sub features are not in the generated plist.